### PR TITLE
Fix notifications not showing for non-overlay chat

### DIFF
--- a/Sources/HMSRoomKit/UIComponents/Conferencing/Internal/HMSChatOverlay.swift
+++ b/Sources/HMSRoomKit/UIComponents/Conferencing/Internal/HMSChatOverlay.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import HMSRoomModels
 
-struct HMSChatOverlay: View {
+struct HMSBottomOverlay: View {
     
     @Environment(\.controlsState) var controlsState
     @Environment(\.tabPageBarState) var tabPageBarState
@@ -82,7 +82,7 @@ struct HMSChatOverlay: View {
     }
 }
 
-struct HMSChatOverlay_Previews: PreviewProvider {
+struct HMSBottomOverlay_Previews: PreviewProvider {
     static var previews: some View {
 #if Preview
         let roomKitModel: HMSRoomNotificationModel = {
@@ -96,7 +96,7 @@ struct HMSChatOverlay_Previews: PreviewProvider {
         
         @State var isChatPresented = true
         
-        HMSChatOverlay(isChatPresented: $isChatPresented, isHLSViewer: false, isChatOverlay: true)
+        HMSBottomOverlay(isChatPresented: $isChatPresented, isHLSViewer: false, isChatOverlay: true)
             .environmentObject(HMSUITheme())
             .environmentObject(HMSRoomModel.dummyRoom(2, [.prominent, .prominent]))
             .environmentObject(roomKitModel)

--- a/Sources/HMSRoomKit/UIComponents/Conferencing/Internal/HMSDefaultConferenceScreen.swift
+++ b/Sources/HMSRoomKit/UIComponents/Conferencing/Internal/HMSDefaultConferenceScreen.swift
@@ -102,10 +102,10 @@ public struct HMSDefaultConferenceScreen: View {
             }
         }
 //        .ignoresSafeArea(.keyboard)
-        // chat overlay
+        // chat bottom overlay (notifications + overlay chat)
         .overlay(alignment: .bottom) {
-            if isChatOverlay && !isHLSViewer {
-                HMSChatOverlay(isChatPresented: $isChatPresented, isHLSViewer: isHLSViewer, isChatOverlay: isChatOverlay)
+            if !isHLSViewer {
+                HMSBottomOverlay(isChatPresented: $isChatPresented, isHLSViewer: isHLSViewer, isChatOverlay: isChatOverlay)
             }
         }
         .overlay {


### PR DESCRIPTION
Show HMSBottomOverlay even when overlay chat is not enabled. because it could be used to show notifications.